### PR TITLE
EditTeamOption struct

### DIFF
--- a/gitea/org_team.go
+++ b/gitea/org_team.go
@@ -18,3 +18,10 @@ type CreateTeamOption struct {
 	Description string `json:"description" binding:"MaxSize(255)"`
 	Permission  string `json:"permission"`
 }
+
+// EditTeamOption options when edit team
+type EditTeamOption struct {
+	Name        string `json:"name" binding:"Required;AlphaDashDot;MaxSize(30)"`
+	Description string `json:"description" binding:"MaxSize(255)"`
+	Permission  string `json:"permission"`
+}


### PR DESCRIPTION
This PR adds an `EditTeamOption` struct to `gitea/org_team.go`. I am planning to add API endpoints for editing/removing an organization's teams, and that will require `EditTeamOption`.

This matches the corresponding [Github parameters](https://developer.github.com/v3/orgs/teams/#edit-team). The only omitted parameter is `privacy`, since (to my knowledge) Gitea does not distinguish between secret/closed teams.

