### PR TITLE
Backward compatibility (username vs. login)

### DIFF
--- a/gitea/user.go
+++ b/gitea/user.go
@@ -5,6 +5,7 @@
 package gitea
 
 import (
+	"encoding/json"
 	"fmt"
 )
 
@@ -15,6 +16,16 @@ type User struct {
 	FullName  string `json:"full_name"`
 	Email     string `json:"email"`
 	AvatarURL string `json:"avatar_url"`
+}
+
+// MarshalJSON implements the json.Marshaler interface for User, adding field(s) for backward compatibility
+func (u User) MarshalJSON() ([]byte, error) {
+	// Re-declaring User to avoid recursion
+	type shadow User
+	return json.Marshal(struct {
+		shadow
+		CompatUserName string `json:"username"`
+	}{shadow(u), u.UserName})
 }
 
 // GetUserInfo get user info by user's name


### PR DESCRIPTION
The [rename](https://github.com/go-gitea/go-sdk/pull/9) from `username` to `login` broke compatibility with Drone and other API consumers.

This PR adds the old username field to `User` on json.Marshal, which resolves these compatibility issues while still maintaining Github-API compliance.

The patch has been tested against Drone 0.4.