### PR TITLE
Issue webhook payload

### DIFF
--- a/gitea/hook.go
+++ b/gitea/hook.go
@@ -1,7 +1,4 @@
 // Copyright 2014 The Gogs Authors. All rights reserved.
-// Use of this source code is governed by a MIT-style
-// license that can be found in the LICENSE file.
-
 // Copyright 2017 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.

--- a/gitea/hook.go
+++ b/gitea/hook.go
@@ -260,6 +260,22 @@ func (p *PushPayload) Branch() string {
 // |___/____  >____  >____/  \___  >
 //          \/     \/            \/
 
+// BaseIssuePayload is the information about a pull request or an issue that
+// is included as an embedded struct in both pull requests and issues.
+type BaseIssuePayload struct {
+	Secret     string          `json:"secret"`
+	Action     HookIssueAction `json:"action"`
+	Index      int64           `json:"number"`
+	Changes    *ChangesPayload `json:"changes,omitempty"`
+	Repository *Repository     `json:"repository"`
+	Sender     *User           `json:"sender"`
+}
+
+// SetSecret modifies the secret of the BaseIssuePayload.
+func (p *BaseIssuePayload) SetSecret(secret string) {
+	p.Secret = secret
+}
+
 // HookIssueAction FIXME
 type HookIssueAction string
 
@@ -296,18 +312,8 @@ const (
 
 // IssuePayload represents the payload information that is sent along with an issue event.
 type IssuePayload struct {
-	Secret     string          `json:"secret"`
-	Action     HookIssueAction `json:"action"`
-	Index      int64           `json:"number"`
-	Changes    *ChangesPayload `json:"changes,omitempty"`
-	Issue      *Issue          `json:"issue"`
-	Repository *Repository     `json:"repository"`
-	Sender     *User           `json:"sender"`
-}
-
-// SetSecret FIXME
-func (p *IssuePayload) SetSecret(secret string) {
-	p.Secret = secret
+	BaseIssuePayload
+	Issue *Issue `json:"issue"`
 }
 
 // JSONPayload FIXME
@@ -336,18 +342,8 @@ type ChangesPayload struct {
 
 // PullRequestPayload represents a payload information of pull request event.
 type PullRequestPayload struct {
-	Secret      string          `json:"secret"`
-	Action      HookIssueAction `json:"action"`
-	Index       int64           `json:"number"`
-	Changes     *ChangesPayload `json:"changes,omitempty"`
-	PullRequest *PullRequest    `json:"pull_request"`
-	Repository  *Repository     `json:"repository"`
-	Sender      *User           `json:"sender"`
-}
-
-// SetSecret FIXME
-func (p *PullRequestPayload) SetSecret(secret string) {
-	p.Secret = secret
+	BaseIssuePayload
+	PullRequest *PullRequest `json:"pull_request"`
 }
 
 // JSONPayload FIXME

--- a/gitea/hook.go
+++ b/gitea/hook.go
@@ -257,22 +257,6 @@ func (p *PushPayload) Branch() string {
 // |___/____  >____  >____/  \___  >
 //          \/     \/            \/
 
-// BaseIssuePayload is the information about a pull request or an issue that
-// is included as an embedded struct in both pull requests and issues.
-type BaseIssuePayload struct {
-	Secret     string          `json:"secret"`
-	Action     HookIssueAction `json:"action"`
-	Index      int64           `json:"number"`
-	Changes    *ChangesPayload `json:"changes,omitempty"`
-	Repository *Repository     `json:"repository"`
-	Sender     *User           `json:"sender"`
-}
-
-// SetSecret modifies the secret of the BaseIssuePayload.
-func (p *BaseIssuePayload) SetSecret(secret string) {
-	p.Secret = secret
-}
-
 // HookIssueAction FIXME
 type HookIssueAction string
 
@@ -309,8 +293,18 @@ const (
 
 // IssuePayload represents the payload information that is sent along with an issue event.
 type IssuePayload struct {
-	BaseIssuePayload
-	Issue *Issue `json:"issue"`
+	Secret     string          `json:"secret"`
+	Action     HookIssueAction `json:"action"`
+	Index      int64           `json:"number"`
+	Changes    *ChangesPayload `json:"changes,omitempty"`
+	Repository *Repository     `json:"repository"`
+	Sender     *User           `json:"sender"`
+	Issue      *Issue          `json:"issue"`
+}
+
+// SetSecret modifies the secret of the IssuePayload.
+func (p *IssuePayload) SetSecret(secret string) {
+	p.Secret = secret
 }
 
 // JSONPayload FIXME
@@ -339,8 +333,18 @@ type ChangesPayload struct {
 
 // PullRequestPayload represents a payload information of pull request event.
 type PullRequestPayload struct {
-	BaseIssuePayload
-	PullRequest *PullRequest `json:"pull_request"`
+	Secret      string          `json:"secret"`
+	Action      HookIssueAction `json:"action"`
+	Index       int64           `json:"number"`
+	Changes     *ChangesPayload `json:"changes,omitempty"`
+	Repository  *Repository     `json:"repository"`
+	Sender      *User           `json:"sender"`
+	PullRequest *PullRequest    `json:"pull_request"`
+}
+
+// SetSecret modifies the secret of the IssuePayload.
+func (p *PullRequestPayload) SetSecret(secret string) {
+	p.Secret = secret
 }
 
 // JSONPayload FIXME

--- a/gitea/hook.go
+++ b/gitea/hook.go
@@ -280,15 +280,9 @@ const (
 	// HookIssueSynchronized synchronized
 	HookIssueSynchronized HookIssueAction = "synchronized"
 	// HookIssueMilestoneSet is an issue action for when a milestone is set on an issue.
-	HookIssueMilestoneSet HookIssueAction = "milestone_set"
+	HookIssueMilestoneSet HookIssueAction = "milestoned"
 	// HookIssueMilestoneCleared is an issue action for when a milestone is cleared on an issue.
-	HookIssueMilestoneCleared HookIssueAction = "milestone_cleared"
-	// HookIssueCommentAdded is an issue action sent when a comment is added to an issue.
-	HookIssueCommentAdded HookIssueAction = "comment_added"
-	// HookIssueCommentDeleted is an issue action sent when a comment on an issue is deleted.
-	HookIssueCommentDeleted HookIssueAction = "comment_deleted"
-	// HookIssueCommentEdited is an issue action sent when a comment on an issue is edited.
-	HookIssueCommentEdited HookIssueAction = "comment_edited"
+	HookIssueMilestoneCleared HookIssueAction = "demilestoned"
 )
 
 // IssuePayload represents the payload information that is sent along with an issue event.
@@ -319,9 +313,8 @@ type ChangesFromPayload struct {
 
 // ChangesPayload FIXME
 type ChangesPayload struct {
-	Title   *ChangesFromPayload `json:"title,omitempty"`
-	Body    *ChangesFromPayload `json:"body,omitempty"`
-	Comment *Comment            `json:"comment,omitempty"`
+	Title *ChangesFromPayload `json:"title,omitempty"`
+	Body  *ChangesFromPayload `json:"body,omitempty"`
 }
 
 // __________      .__  .__    __________                                     __

--- a/gitea/hook.go
+++ b/gitea/hook.go
@@ -2,6 +2,10 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
 package gitea
 
 import (

--- a/gitea/hook.go
+++ b/gitea/hook.go
@@ -147,6 +147,7 @@ type PayloadCommit struct {
 var (
 	_ Payloader = &CreatePayload{}
 	_ Payloader = &PushPayload{}
+	_ Payloader = &IssuePayload{}
 	_ Payloader = &PullRequestPayload{}
 )
 
@@ -277,7 +278,38 @@ const (
 	HookIssueLabelCleared HookIssueAction = "label_cleared"
 	// HookIssueSynchronized synchronized
 	HookIssueSynchronized HookIssueAction = "synchronized"
+	// HookIssueMilestoneSet is an issue action for when a milestone is set on an issue.
+	HookIssueMilestoneSet HookIssueAction = "milestone_set"
+	// HookIssueMilestoneCleared is an issue action for when a milestone is cleared on an issue.
+	HookIssueMilestoneCleared HookIssueAction = "milestone_cleared"
+	// HookIssueCommentAdded is an issue action sent when a comment is added to an issue.
+	HookIssueCommentAdded HookIssueAction = "comment_added"
+	// HookIssueCommentDeleted is an issue action sent when a comment on an issue is deleted.
+	HookIssueCommentDeleted HookIssueAction = "comment_deleted"
+	// HookIssueCommentEdited is an issue action sent when a comment on an issue is edited.
+	HookIssueCommentEdited HookIssueAction = "comment_edited"
 )
+
+// IssuePayload represents the payload information that is sent along with an issue event.
+type IssuePayload struct {
+	Secret     string          `json:"secret"`
+	Action     HookIssueAction `json:"action"`
+	Index      int64           `json:"number"`
+	Changes    *ChangesPayload `json:"changes,omitempty"`
+	Issue      *Issue          `json:"issue"`
+	Repository *Repository     `json:"repository"`
+	Sender     *User           `json:"sender"`
+}
+
+// SetSecret FIXME
+func (p *IssuePayload) SetSecret(secret string) {
+	p.Secret = secret
+}
+
+// JSONPayload FIXME
+func (p *IssuePayload) JSONPayload() ([]byte, error) {
+	return json.MarshalIndent(p, "", "  ")
+}
 
 // ChangesFromPayload FIXME
 type ChangesFromPayload struct {
@@ -286,8 +318,9 @@ type ChangesFromPayload struct {
 
 // ChangesPayload FIXME
 type ChangesPayload struct {
-	Title *ChangesFromPayload `json:"title,omitempty"`
-	Body  *ChangesFromPayload `json:"body,omitempty"`
+	Title   *ChangesFromPayload `json:"title,omitempty"`
+	Body    *ChangesFromPayload `json:"body,omitempty"`
+	Comment *Comment            `json:"comment,omitempty"`
 }
 
 // __________      .__  .__    __________                                     __

--- a/gitea/hook.go
+++ b/gitea/hook.go
@@ -297,9 +297,9 @@ type IssuePayload struct {
 	Action     HookIssueAction `json:"action"`
 	Index      int64           `json:"number"`
 	Changes    *ChangesPayload `json:"changes,omitempty"`
+	Issue      *Issue          `json:"issue"`
 	Repository *Repository     `json:"repository"`
 	Sender     *User           `json:"sender"`
-	Issue      *Issue          `json:"issue"`
 }
 
 // SetSecret modifies the secret of the IssuePayload.
@@ -337,9 +337,9 @@ type PullRequestPayload struct {
 	Action      HookIssueAction `json:"action"`
 	Index       int64           `json:"number"`
 	Changes     *ChangesPayload `json:"changes,omitempty"`
+	PullRequest *PullRequest    `json:"pull_request"`
 	Repository  *Repository     `json:"repository"`
 	Sender      *User           `json:"sender"`
-	PullRequest *PullRequest    `json:"pull_request"`
 }
 
 // SetSecret modifies the secret of the PullRequestPayload.

--- a/gitea/hook.go
+++ b/gitea/hook.go
@@ -279,10 +279,10 @@ const (
 	HookIssueLabelCleared HookIssueAction = "label_cleared"
 	// HookIssueSynchronized synchronized
 	HookIssueSynchronized HookIssueAction = "synchronized"
-	// HookIssueMilestoneSet is an issue action for when a milestone is set on an issue.
-	HookIssueMilestoneSet HookIssueAction = "milestoned"
-	// HookIssueMilestoneCleared is an issue action for when a milestone is cleared on an issue.
-	HookIssueMilestoneCleared HookIssueAction = "demilestoned"
+	// HookIssueMilestoned is an issue action for when a milestone is set on an issue.
+	HookIssueMilestoned HookIssueAction = "milestoned"
+	// HookIssueDemilestoned is an issue action for when a milestone is cleared on an issue.
+	HookIssueDemilestoned HookIssueAction = "demilestoned"
 )
 
 // IssuePayload represents the payload information that is sent along with an issue event.

--- a/gitea/hook.go
+++ b/gitea/hook.go
@@ -307,7 +307,7 @@ func (p *IssuePayload) SetSecret(secret string) {
 	p.Secret = secret
 }
 
-// JSONPayload FIXME
+// JSONPayload encodes the IssuePayload to JSON, with an indentation of two spaces.
 func (p *IssuePayload) JSONPayload() ([]byte, error) {
 	return json.MarshalIndent(p, "", "  ")
 }

--- a/gitea/hook.go
+++ b/gitea/hook.go
@@ -342,7 +342,7 @@ type PullRequestPayload struct {
 	PullRequest *PullRequest    `json:"pull_request"`
 }
 
-// SetSecret modifies the secret of the IssuePayload.
+// SetSecret modifies the secret of the PullRequestPayload.
 func (p *PullRequestPayload) SetSecret(secret string) {
 	p.Secret = secret
 }

--- a/gitea/issue.go
+++ b/gitea/issue.go
@@ -2,6 +2,10 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
 package gitea
 
 import (

--- a/gitea/issue.go
+++ b/gitea/issue.go
@@ -2,10 +2,6 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-// Copyright 2017 The Gitea Authors. All rights reserved.
-// Use of this source code is governed by a MIT-style
-// license that can be found in the LICENSE file.
-
 package gitea
 
 import (


### PR DESCRIPTION
This PR prepares for an upcoming pull request on the main repository that aims to implement https://github.com/go-gitea/gitea/issues/132, adding webhook for issue events.

A small API breakage would be introduced in the SDK (though the API JSON objects' structure would remain untouched, if not for some shifting of the position of the fields). As most fields between the PullRequestPayload and the IssuePayload would be the same, the idea is to move the fields to a common BaseIssuePayload, although this would bring a small breakage to when constructing the struct of a PullRequestPayload:

```go
// No longer possible after this PR
pr := &gitea.PullRequestPayload{
	Index: 64, 
}
```

However, accessing the struct fields would still be possible after the struct is initialised.

```go
pr := &gitea.PullRequestPayload{}
pr.Index = 64
_ = pr.Index
```

This would be, however, a very small issue, as the PullRequestPayload is only initialised by Gitea itself ([see this github search](https://github.com/search?utf8=%E2%9C%93&q=code.gitea.io%2Fsdk+PullRequestPayload&type=Code&ref=searchresults)), but Gitea vendors its dependencies anyway, so this would break only in the event of a vendor update with no update to models/issue.go's struct initialisations.