### PR TITLE
Add missing ListGPGKeys of a user

### DIFF
--- a/gitea/user_gpgkey.go
+++ b/gitea/user_gpgkey.go
@@ -38,6 +38,12 @@ type CreateGPGKeyOption struct {
 	ArmoredKey string `json:"armored_public_key" binding:"Required"`
 }
 
+// ListGPGKeys list all the GPG keys of the user
+func (c *Client) ListGPGKeys(user string) ([]*GPGKey, error) {
+	keys := make([]*GPGKey, 0, 10)
+	return keys, c.getParsedResponse("GET", fmt.Sprintf("/users/%s/gpg_keys", user), nil, nil, &keys)
+}
+
 // ListMyGPGKeys list all the GPG keys of current user
 func (c *Client) ListMyGPGKeys() ([]*GPGKey, error) {
 	keys := make([]*GPGKey, 0, 10)


### PR DESCRIPTION
In PR #36, I forgot the request GET /users/:username/gpg_keys that is similar in content to GET /user/gpg_keys for current user and similar in request form to /users/:username/keys in https://github.com/go-gitea/go-sdk/blob/master/gitea/user_key.go#L24

Implemented in go-gitea/gitea#710