### PR TITLE
Added read-only attachments to the Releases API

### DIFF
--- a/gitea/attachment.go
+++ b/gitea/attachment.go
@@ -5,7 +5,7 @@
 package gitea // import "code.gitea.io/sdk/gitea"
 import "time"
 
-// a generic attachment
+// Attachment a generic attachment
 type Attachment struct {
 	ID            int64     `json:"id"`
 	Name          string    `json:"name"`

--- a/gitea/attachment.go
+++ b/gitea/attachment.go
@@ -1,0 +1,17 @@
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package gitea // import "code.gitea.io/sdk/gitea"
+import "time"
+
+// a generic attachment
+type Attachment struct {
+	ID            int64     `json:"id"`
+	Name          string    `json:"name"`
+	Size          int64     `json:"size"`
+	DownloadCount int64     `json:"download_count"`
+	Created       time.Time `json:"created_at"`
+	UUID          string    `json:"uuid"`
+	DownloadURL   string    `json:"browser_download_url"`
+}

--- a/gitea/release.go
+++ b/gitea/release.go
@@ -47,6 +47,24 @@ func (c *Client) GetRelease(user, repo string, id int64) (*Release, error) {
 	return r, err
 }
 
+// ListReleaseAssets gets all the assets of a release in a repository
+func (c *Client) ListReleaseAssets(user, repo string, id int64) (*Release, error) {
+	r := new(Release)
+	err := c.getParsedResponse("GET",
+		fmt.Sprintf("/repos/%s/%s/releases/%d/assets", user, repo, id),
+		nil, nil, &r)
+	return r, err
+}
+
+// GetReleaseAsset gets all the assets of a release in a repository
+func (c *Client) GetReleaseAsset(user, repo string, releaseId int64, assetId int64) (*Release, error) {
+	r := new(Release)
+	err := c.getParsedResponse("GET",
+		fmt.Sprintf("/repos/%s/%s/releases/%d/assets/%d", user, repo, releaseId, assetId),
+		nil, nil, &r)
+	return r, err
+}
+
 // CreateReleaseOption options when creating a release
 type CreateReleaseOption struct {
 	TagName      string `json:"tag_name" binding:"Required"`

--- a/gitea/release.go
+++ b/gitea/release.go
@@ -66,10 +66,10 @@ func (c *Client) GetReleaseAsset(user, repo string, releaseID int64, assetID int
 }
 
 // GetLatestRelease gets the latest release in a repository
-func (c *Client) GetLatestRelease(user, repo string, id int64) (*Release, error) {
+func (c *Client) GetLatestRelease(user, repo string) (*Release, error) {
 	r := new(Release)
 	err := c.getParsedResponse("GET",
-		fmt.Sprintf("/repos/%s/%s/releases/latest", user, repo, id),
+		fmt.Sprintf("/repos/%s/%s/releases/latest", user, repo),
 		nil, nil, &r)
 	return r, err
 }

--- a/gitea/release.go
+++ b/gitea/release.go
@@ -65,6 +65,15 @@ func (c *Client) GetReleaseAsset(user, repo string, releaseID int64, assetID int
 	return r, err
 }
 
+// GetLatestRelease gets the latest release in a repository
+func (c *Client) GetLatestRelease(user, repo string, id int64) (*Release, error) {
+	r := new(Release)
+	err := c.getParsedResponse("GET",
+		fmt.Sprintf("/repos/%s/%s/releases/latest", user, repo, id),
+		nil, nil, &r)
+	return r, err
+}
+
 // CreateReleaseOption options when creating a release
 type CreateReleaseOption struct {
 	TagName      string `json:"tag_name" binding:"Required"`

--- a/gitea/release.go
+++ b/gitea/release.go
@@ -47,8 +47,8 @@ func (c *Client) GetRelease(user, repo string, id int64) (*Release, error) {
 	return r, err
 }
 
-// ListReleaseAssets gets all the assets of a release in a repository
-func (c *Client) ListReleaseAssets(user, repo string, id int64) (*Release, error) {
+// ListReleaseAttachments gets all the assets of a release in a repository
+func (c *Client) ListReleaseAttachments(user, repo string, id int64) (*Release, error) {
 	r := new(Release)
 	err := c.getParsedResponse("GET",
 		fmt.Sprintf("/repos/%s/%s/releases/%d/assets", user, repo, id),
@@ -56,11 +56,11 @@ func (c *Client) ListReleaseAssets(user, repo string, id int64) (*Release, error
 	return r, err
 }
 
-// GetReleaseAsset gets all the assets of a release in a repository
-func (c *Client) GetReleaseAsset(user, repo string, releaseID int64, assetID int64) (*Release, error) {
+// GetReleaseAttachment gets all the assets of a release in a repository
+func (c *Client) GetReleaseAttachment(user, repo string, releaseID int64, attachmentID int64) (*Release, error) {
 	r := new(Release)
 	err := c.getParsedResponse("GET",
-		fmt.Sprintf("/repos/%s/%s/releases/%d/assets/%d", user, repo, releaseID, assetID),
+		fmt.Sprintf("/repos/%s/%s/releases/%d/assets/%d", user, repo, releaseID, attachmentID),
 		nil, nil, &r)
 	return r, err
 }

--- a/gitea/release.go
+++ b/gitea/release.go
@@ -48,24 +48,24 @@ func (c *Client) GetRelease(user, repo string, id int64) (*Release, error) {
 }
 
 // ListReleaseAttachments gets all the assets of a release in a repository
-func (c *Client) ListReleaseAttachments(user, repo string, id int64) (*Release, error) {
-	r := new(Release)
+func (c *Client) ListReleaseAttachments(user, repo string, id int64) ([]*Attachment, error) {
+	attachments := make([]*Attachment, 0, 10)
 	err := c.getParsedResponse("GET",
 		fmt.Sprintf("/repos/%s/%s/releases/%d/assets", user, repo, id),
-		nil, nil, &r)
-	return r, err
+		nil, nil, &attachments)
+	return attachments, err
 }
 
-// GetReleaseAttachment gets all the assets of a release in a repository
-func (c *Client) GetReleaseAttachment(user, repo string, releaseID int64, attachmentID int64) (*Release, error) {
-	r := new(Release)
+// GetReleaseAttachment gets a single attachment of a release in a repository
+func (c *Client) GetReleaseAttachment(user, repo string, releaseID int64, attachmentID int64) (*Attachment, error) {
+	attachment := new(Attachment)
 	err := c.getParsedResponse("GET",
 		fmt.Sprintf("/repos/%s/%s/releases/%d/assets/%d", user, repo, releaseID, attachmentID),
-		nil, nil, &r)
-	return r, err
+		nil, nil, &attachment)
+	return attachment, err
 }
 
-// GetLatestRelease gets the latest release in a repository
+// GetLatestRelease gets the latest release in a repository. This cannot be a draft or prerelease
 func (c *Client) GetLatestRelease(user, repo string) (*Release, error) {
 	r := new(Release)
 	err := c.getParsedResponse("GET",

--- a/gitea/release.go
+++ b/gitea/release.go
@@ -57,10 +57,10 @@ func (c *Client) ListReleaseAssets(user, repo string, id int64) (*Release, error
 }
 
 // GetReleaseAsset gets all the assets of a release in a repository
-func (c *Client) GetReleaseAsset(user, repo string, releaseId int64, assetId int64) (*Release, error) {
+func (c *Client) GetReleaseAsset(user, repo string, releaseID int64, assetID int64) (*Release, error) {
 	r := new(Release)
 	err := c.getParsedResponse("GET",
-		fmt.Sprintf("/repos/%s/%s/releases/%d/assets/%d", user, repo, releaseId, assetId),
+		fmt.Sprintf("/repos/%s/%s/releases/%d/assets/%d", user, repo, releaseID, assetID),
 		nil, nil, &r)
 	return r, err
 }

--- a/gitea/release.go
+++ b/gitea/release.go
@@ -13,19 +13,20 @@ import (
 
 // Release represents a repository release
 type Release struct {
-	ID           int64     `json:"id"`
-	TagName      string    `json:"tag_name"`
-	Target       string    `json:"target_commitish"`
-	Title        string    `json:"name"`
-	Note         string    `json:"body"`
-	URL          string    `json:"url"`
-	TarURL       string    `json:"tarball_url"`
-	ZipURL       string    `json:"zipball_url"`
-	IsDraft      bool      `json:"draft"`
-	IsPrerelease bool      `json:"prerelease"`
-	CreatedAt    time.Time `json:"created_at"`
-	PublishedAt  time.Time `json:"published_at"`
-	Publisher    *User     `json:"author"`
+	ID           int64         `json:"id"`
+	TagName      string        `json:"tag_name"`
+	Target       string        `json:"target_commitish"`
+	Title        string        `json:"name"`
+	Note         string        `json:"body"`
+	URL          string        `json:"url"`
+	TarURL       string        `json:"tarball_url"`
+	ZipURL       string        `json:"zipball_url"`
+	IsDraft      bool          `json:"draft"`
+	IsPrerelease bool          `json:"prerelease"`
+	CreatedAt    time.Time     `json:"created_at"`
+	PublishedAt  time.Time     `json:"published_at"`
+	Publisher    *User         `json:"author"`
+	Attachments  []*Attachment `json:"assets"`
 }
 
 // ListReleases list releases of a repository


### PR DESCRIPTION
Added a assets array to the releases GET request. This is a required change for https://github.com/go-gitea/gitea/pull/2084
* Get releases `GET /repos/:owner/:repo/releases[/:id]` - now includes assets
* List assets: `GET /repos/:owner/:repo/releases/:id/assets`
* Get single asset: `GET /repos/:owner/:repo/releases/assets/:id`