### PR TITLE
Fix request URL in ServerVersion function

### DIFF
--- a/gitea/miscellaneous.go
+++ b/gitea/miscellaneous.go
@@ -52,5 +52,5 @@ type ServerVersion struct {
 // ServerVersion returns the version of the server
 func (c *Client) ServerVersion() (string, error) {
 	v := ServerVersion{}
-	return v.Version, c.getParsedResponse("GET", "/api/v1/version", nil, nil, &v)
+	return v.Version, c.getParsedResponse("GET", "/version", nil, nil, &v)
 }


### PR DESCRIPTION
"/api/v1"  is useless, it is already included by func (c *Client) getParsedResponse(...)