### PR TITLE
Require password when creating user

### DIFF
--- a/gitea/admin_user.go
+++ b/gitea/admin_user.go
@@ -24,7 +24,7 @@ type CreateUserOption struct {
 	// in: body
 	Email string `json:"email" binding:"Required;Email;MaxSize(254)"`
 	// in: body
-	Password string `json:"password" binding:"MaxSize(255)"`
+	Password string `json:"password" binding:"Required;MaxSize(255)"`
 	// in: body
 	SendNotify bool `json:"send_notify"`
 }


### PR DESCRIPTION
Require the `password` field to be populated when creating a user from the admin API endpoint.

If the field is not explicitly populated, the password will be the empty string, and the newly-created user will not be able to log in from the web UI.
