### PR TITLE
Add Search users support

### DIFF
--- a/gitea/user_search.go
+++ b/gitea/user_search.go
@@ -1,0 +1,14 @@
+package gitea
+
+import "fmt"
+
+type searchUsersResponse struct {
+	Users []*User `json:"data"`
+}
+
+// SearchUsers finds users by query
+func (c *Client) SearchUsers(query string, limit int) ([]*User, error) {
+	resp := new(searchUsersResponse)
+	err := c.getParsedResponse("GET", fmt.Sprintf("/users/search?q=%s&limit=%d", query, limit), nil, nil, &resp)
+	return resp.Users, err
+}


### PR DESCRIPTION
Hi, it looks like there is no search users method 

but API https://try.gitea.io/api/swagger#/ exists
`/users/search`

This PR adds this method.
 
Signed-off-by: Serhii Kuts <sergeykuc@gmail.com>