### PR TITLE
Add closed at field for issue and pull request

### DIFF
--- a/gitea/issue.go
+++ b/gitea/issue.go
@@ -49,6 +49,8 @@ type Issue struct {
 	Created time.Time `json:"created_at"`
 	// swagger:strfmt date-time
 	Updated time.Time `json:"updated_at"`
+	// swagger:strfmt date-time
+	Closed *time.Time `json:"closed_at"`
 
 	PullRequest *PullRequestMeta `json:"pull_request"`
 }

--- a/gitea/pull.go
+++ b/gitea/pull.go
@@ -44,6 +44,8 @@ type PullRequest struct {
 	Created *time.Time `json:"created_at"`
 	// swagger:strfmt date-time
 	Updated *time.Time `json:"updated_at"`
+	// swagger:strfmt date-time
+	Closed *time.Time `json:"closed_at"`
 }
 
 // PRBranchInfo information about a branch


### PR DESCRIPTION
Now that go-gitea/gitea#3537 has closed value stored in database for GitHub compatibility we can also return this field