### PR TITLE
Added user locale setting

### DIFF
--- a/gitea/user.go
+++ b/gitea/user.go
@@ -22,6 +22,8 @@ type User struct {
 	Email string `json:"email"`
 	// URL to the user's avatar
 	AvatarURL string `json:"avatar_url"`
+	// User locale
+	Language string `json:"language"`
 }
 
 // MarshalJSON implements the json.Marshaler interface for User, adding field(s) for backward compatibility


### PR DESCRIPTION
This pr adds a users locale to the `user` struct.
This is needed to manage a user's locale via the api (pr in for gitea main coming soon)