### PR TITLE
Added deadline structs for api

### DIFF
--- a/gitea/issue.go
+++ b/gitea/issue.go
@@ -118,14 +118,14 @@ func (c *Client) CreateIssue(owner, repo string, opt CreateIssueOption) (*Issue,
 
 // EditIssueOption options for editing an issue
 type EditIssueOption struct {
-	Title     string     `json:"title"`
-	Body      *string    `json:"body"`
-	Assignee  *string    `json:"assignee"`
-	Assignees []string   `json:"assignees"`
-	Milestone *int64     `json:"milestone"`
-	State     *string    `json:"state"`
+	Title     string   `json:"title"`
+	Body      *string  `json:"body"`
+	Assignee  *string  `json:"assignee"`
+	Assignees []string `json:"assignees"`
+	Milestone *int64   `json:"milestone"`
+	State     *string  `json:"state"`
 	// swagger:strfmt date-time
-	Deadline  *time.Time `json:"due_date"`
+	Deadline *time.Time `json:"due_date"`
 }
 
 // EditIssue modify an existing issue for a given repository
@@ -139,11 +139,11 @@ func (c *Client) EditIssue(owner, repo string, index int64, opt EditIssueOption)
 		jsonHeader, bytes.NewReader(body), issue)
 }
 
-// CreateDeadlineOption options for creating a deadline
+// EditDeadlineOption options for creating a deadline
 type EditDeadlineOption struct {
 	// required:true
 	// swagger:strfmt date-time
-	Deadline  *time.Time `json:"due_date"`
+	Deadline *time.Time `json:"due_date"`
 }
 
 // IssueDeadline represents an issue deadline

--- a/gitea/issue.go
+++ b/gitea/issue.go
@@ -138,3 +138,17 @@ func (c *Client) EditIssue(owner, repo string, index int64, opt EditIssueOption)
 	return issue, c.getParsedResponse("PATCH", fmt.Sprintf("/repos/%s/%s/issues/%d", owner, repo, index),
 		jsonHeader, bytes.NewReader(body), issue)
 }
+
+// CreateDeadlineOption options for creating a deadline
+type EditDeadlineOption struct {
+	// required:true
+	// swagger:strfmt date-time
+	Deadline  *time.Time `json:"due_date"`
+}
+
+// IssueDeadline represents an issue deadline
+// swagger:model
+type IssueDeadline struct {
+	// swagger:strfmt date-time
+	Deadline *time.Time `json:"due_date"`
+}

--- a/gitea/pull.go
+++ b/gitea/pull.go
@@ -85,16 +85,16 @@ func (c *Client) GetPullRequest(owner, repo string, index int64) (*PullRequest, 
 
 // CreatePullRequestOption options when creating a pull request
 type CreatePullRequestOption struct {
-	Head      string     `json:"head" binding:"Required"`
-	Base      string     `json:"base" binding:"Required"`
-	Title     string     `json:"title" binding:"Required"`
-	Body      string     `json:"body"`
-	Assignee  string     `json:"assignee"`
-	Assignees []string   `json:"assignees"`
-	Milestone int64      `json:"milestone"`
-	Labels    []int64    `json:"labels"`
+	Head      string   `json:"head" binding:"Required"`
+	Base      string   `json:"base" binding:"Required"`
+	Title     string   `json:"title" binding:"Required"`
+	Body      string   `json:"body"`
+	Assignee  string   `json:"assignee"`
+	Assignees []string `json:"assignees"`
+	Milestone int64    `json:"milestone"`
+	Labels    []int64  `json:"labels"`
 	// swagger:strfmt date-time
-	Deadline  *time.Time `json:"due_date"`
+	Deadline *time.Time `json:"due_date"`
 }
 
 // CreatePullRequest create pull request with options
@@ -110,15 +110,15 @@ func (c *Client) CreatePullRequest(owner, repo string, opt CreatePullRequestOpti
 
 // EditPullRequestOption options when modify pull request
 type EditPullRequestOption struct {
-	Title     string     `json:"title"`
-	Body      string     `json:"body"`
-	Assignee  string     `json:"assignee"`
-	Assignees []string   `json:"assignees"`
-	Milestone int64      `json:"milestone"`
-	Labels    []int64    `json:"labels"`
-	State     *string    `json:"state"`
+	Title     string   `json:"title"`
+	Body      string   `json:"body"`
+	Assignee  string   `json:"assignee"`
+	Assignees []string `json:"assignees"`
+	Milestone int64    `json:"milestone"`
+	Labels    []int64  `json:"labels"`
+	State     *string  `json:"state"`
 	// swagger:strfmt date-time
-	Deadline  *time.Time `json:"due_date"`
+	Deadline *time.Time `json:"due_date"`
 }
 
 // EditPullRequest modify pull request with PR id and options


### PR DESCRIPTION
This pr adds deadline structs to be able to manage deadlines via the api.

Blocks go-gitea/gitea#3890.