### PR TITLE
Refactoring access token from sha1 to sha1+JWT

### DIFF
--- a/gitea/user_app.go
+++ b/gitea/user_app.go
@@ -42,7 +42,7 @@ func (c *Client) ListAccessTokens(user, pass string) ([]*AccessToken, error) {
 func (c *Client) AdminListAccessTokens(user, serverToken string) ([]*AccessToken, error) {
 	tokens := make([]*AccessToken, 0, 10)
 	return tokens, c.getParsedResponse("GET", fmt.Sprintf("/users/%s/tokens", user),
-		http.Header{"X-Gitea-Server-Access-Token": []string{serverToken}}, nil, &tokens)
+		http.Header{"X-Gitea-Server-Access-Token": []string{serverToken} }, nil, &tokens)
 }
 
 // CreateAccessTokenOption options when create access token

--- a/gitea/user_app.go
+++ b/gitea/user_app.go
@@ -43,15 +43,16 @@ type CreateAccessTokenOption struct {
 	Name string `json:"name" binding:"Required"`
 	MatchOwner []string `json:"match_owner,omitempty"`
 	MatchRepo []string `json:"match_repo,omitempty"`
-	RegexMatchBranch []string `json:"regex_match_branch,omitempty"`
-	RegexMatchRoute []string `json:"regex_match_route,omitempty"`
+	WildcardMatchBranch []string `json:"wildcard_match_branch,omitempty"`
+	WildcardMatchRoute []string `json:"wildcard_match_route,omitempty"`
 	MatchMethod []string `json:"match_method,omitempty"`
-	Expires int64 `json:"expires,omitempty"`
+	ExpiresAt int64 `json:"expires_at,omitempty"`
 	// allow integrated server app to authenticate by pre-generated token
 	// and to deprecate basic auth by username and password.
 	// this will also give server app the option to generate user access token
 	// on the fly without storing token.
 	GiteaServerAccessToken string `json:"-"`
+	UserName 		string `json:"user_name,omitempty"`
 }
 
 // CreateAccessToken create one access token with options

--- a/gitea/user_app.go
+++ b/gitea/user_app.go
@@ -37,6 +37,14 @@ func (c *Client) ListAccessTokens(user, pass string) ([]*AccessToken, error) {
 		http.Header{"Authorization": []string{"Basic " + BasicAuthEncode(user, pass)}}, nil, &tokens)
 }
 
+// AdminListAccessTokens lista all the access tokens of user, authenticate with pre-generated server token.
+// this allows server app to list and generate access token for a user already authenticated through other means.
+func (c *Client) AdminListAccessTokens(user, server_token string) ([]*AccessToken, error) {
+	tokens := make([]*AccessToken, 0, 10)
+	return tokens, c.getParsedResponse("GET", fmt.Sprintf("/users/%s/tokens", user),
+		http.Header{"X-Gitea-Server-Access-Token": []string{server_token}}, nil, &tokens)
+}
+
 // CreateAccessTokenOption options when create access token
 // swagger:parameters userCreateToken
 type CreateAccessTokenOption struct {

--- a/gitea/user_app.go
+++ b/gitea/user_app.go
@@ -39,10 +39,10 @@ func (c *Client) ListAccessTokens(user, pass string) ([]*AccessToken, error) {
 
 // AdminListAccessTokens lista all the access tokens of user, authenticate with pre-generated server token.
 // this allows server app to list and generate access token for a user already authenticated through other means.
-func (c *Client) AdminListAccessTokens(user, server_token string) ([]*AccessToken, error) {
+func (c *Client) AdminListAccessTokens(user, serverToken string) ([]*AccessToken, error) {
 	tokens := make([]*AccessToken, 0, 10)
 	return tokens, c.getParsedResponse("GET", fmt.Sprintf("/users/%s/tokens", user),
-		http.Header{"X-Gitea-Server-Access-Token": []string{server_token}}, nil, &tokens)
+		http.Header{"X-Gitea-Server-Access-Token": []string{serverToken}}, nil, &tokens)
 }
 
 // CreateAccessTokenOption options when create access token

--- a/gitea/user_app.go
+++ b/gitea/user_app.go
@@ -23,6 +23,7 @@ type AccessToken struct {
 	ID   int64  `json:"id"`
 	Name string `json:"name"`
 	Sha1 string `json:"sha1"`
+	Content string `json:"content,omitempty"`
 }
 
 // AccessTokenList represents a list of API access token.
@@ -40,6 +41,17 @@ func (c *Client) ListAccessTokens(user, pass string) ([]*AccessToken, error) {
 // swagger:parameters userCreateToken
 type CreateAccessTokenOption struct {
 	Name string `json:"name" binding:"Required"`
+	MatchOwner []string `json:"match_owner,omitempty"`
+	MatchRepo []string `json:"match_repo,omitempty"`
+	RegexMatchBranch []string `json:"regex_match_branch,omitempty"`
+	RegexMatchRoute []string `json:"regex_match_route,omitempty"`
+	MatchMethod []string `json:"match_method,omitempty"`
+	Expires int64 `json:"expires,omitempty"`
+	// allow integrated server app to authenticate by pre-generated token
+	// and to deprecate basic auth by username and password.
+	// this will also give server app the option to generate user access token
+	// on the fly without storing token.
+	GiteaServerAccessToken string `json:"-"`
 }
 
 // CreateAccessToken create one access token with options
@@ -52,7 +64,9 @@ func (c *Client) CreateAccessToken(user, pass string, opt CreateAccessTokenOptio
 	return t, c.getParsedResponse("POST", fmt.Sprintf("/users/%s/tokens", user),
 		http.Header{
 			"content-type":  []string{"application/json"},
-			"Authorization": []string{"Basic " + BasicAuthEncode(user, pass)}},
+			"Authorization": []string{"Basic " + BasicAuthEncode(user, pass)},
+			"X-Gitea-Server-Access-Token": []string{opt.GiteaServerAccessToken},
+		},
 		bytes.NewReader(body), t)
 }
 

--- a/gitea/user_app.go
+++ b/gitea/user_app.go
@@ -60,7 +60,6 @@ type CreateAccessTokenOption struct {
 	// this will also give server app the option to generate user access token
 	// on the fly without storing token.
 	GiteaServerAccessToken string `json:"-"`
-	UserName 		string `json:"user_name,omitempty"`
 }
 
 // CreateAccessToken create one access token with options


### PR DESCRIPTION
AccessToken returned from API can include JWT as content, and sha1 hash of the content for backward compatibility. during transition period, the api can accept old and new sha1, and allow integrated apps to use JWT in the future.
