### PR TITLE
Update SDK to match the return of /users/search

### DIFF
--- a/gitea/user_search.go
+++ b/gitea/user_search.go
@@ -2,13 +2,15 @@ package gitea
 
 import "fmt"
 
-type searchUsersResponse struct {
-	Users []*User `json:"data"`
+// UserSearchResults results of a succesful user search
+type UserSearchResults struct {
+	OK   bool    `json:"ok"`
+	Data []*User `json:"data"`
 }
 
 // SearchUsers finds users by query
 func (c *Client) SearchUsers(query string, limit int) ([]*User, error) {
-	resp := new(searchUsersResponse)
+	resp := new(UserSearchResults)
 	err := c.getParsedResponse("GET", fmt.Sprintf("/users/search?q=%s&limit=%d", query, limit), nil, nil, &resp)
-	return resp.Users, err
+	return resp.Data, err
 }


### PR DESCRIPTION
As per issue https://github.com/go-gitea/gitea/issues/4841. The current implementation of the `/users/search` API does not return a UserList but rather an object similar to the SearchResults object returned by `/repos/search`. This pull request fixes swagger API so that it actually describes the reality of what is returned. 

The issue is that this API has been wrong for at least 10 months - therefore tools may have grown up using the incorrect API. I have also created a pull request for the opposite solution https://github.com/go-gitea/gitea/pull/4846 - which if pulled would mean this request was unnecessary.