### PR TITLE
Adjust keys API

### DIFF
--- a/gitea/repo_key.go
+++ b/gitea/repo_key.go
@@ -14,6 +14,7 @@ import (
 // DeployKey a deploy key
 type DeployKey struct {
 	ID    int64  `json:"id"`
+	KeyID int64  `json:"key_id"`
 	Key   string `json:"key"`
 	URL   string `json:"url"`
 	Title string `json:"title"`

--- a/gitea/user_key.go
+++ b/gitea/user_key.go
@@ -19,7 +19,10 @@ type PublicKey struct {
 	Title       string `json:"title,omitempty"`
 	Fingerprint string `json:"fingerprint,omitempty"`
 	// swagger:strfmt date-time
-	Created time.Time `json:"created_at,omitempty"`
+	Created  time.Time `json:"created_at,omitempty"`
+	Owner    *User     `json:"user,omitempty"`
+	ReadOnly bool      `json:"read_only,omitempty"`
+	KeyType  string    `json:"key_type,omitempty"`
 }
 
 // ListPublicKeys list all the public keys of the user


### PR DESCRIPTION
The results of the API for both the repo ssh keys and the user ssh keys lacks several important features.

This pull request adjusts the API to allow reporting of the key id for the keys reported by  `/repos/{owner}/{repo}/keys` and the owner, keytype and read_only type for the keys reported by `/user/keys`.

(Of note `/user/keys` does not only just return user keys but also deploy keys.)
