### PR TITLE
added recursive support to git trees api

### DIFF
--- a/gitea/repo_tree.go
+++ b/gitea/repo_tree.go
@@ -28,8 +28,12 @@ type GitTreeResponse struct {
 
 // GetTrees downloads a file of repository, ref can be branch/tag/commit.
 // e.g.: ref -> master, tree -> macaron.go(no leading slash)
-func (c *Client) GetTrees(user, repo, ref string) (*GitTreeResponse, error) {
+func (c *Client) GetTrees(user, repo, ref string, recursive bool) (*GitTreeResponse, error) {
 	var trees GitTreeResponse
-	_, err := c.getResponse("GET", fmt.Sprintf("/repos/%s/%s/git/trees/%s", user, repo, ref), nil, nil)
+	var path = fmt.Sprintf("/repos/%s/%s/git/trees/%s", user, repo, ref)
+	if recursive {
+		path += "?recursive=1"
+	}
+	err := c.getParsedResponse("GET", path, nil, nil, &trees)
 	return &trees, err
 }


### PR DESCRIPTION
This PR adds recursive support to the SDK. I also noticed that there was a small bug with #94 - (untested).

`var trees GitTreeResponse` never seems to be populated. This PR fixes that.