### PR TITLE
Revert PR #133

### DIFF
--- a/gitea/release.go
+++ b/gitea/release.go
@@ -53,7 +53,7 @@ func (c *Client) GetRelease(user, repo string, id int64) (*Release, error) {
 type CreateReleaseOption struct {
 	// required: true
 	TagName      string `json:"tag_name" binding:"Required"`
-	Target       string `json:"target_commitish" binding:"Required"`
+	Target       string `json:"target_commitish"`
 	Title        string `json:"name"`
 	Note         string `json:"body"`
 	IsDraft      bool   `json:"draft"`


### PR DESCRIPTION
Reverting as that breaks drone CI integration, it should be fixed to use default branch if none is specified in Gitea API side