### PR TITLE
Updates GitTreeResponse for pagination

### DIFF
--- a/gitea/repo_tree.go
+++ b/gitea/repo_tree.go
@@ -26,7 +26,6 @@ type GitTreeResponse struct {
 	Truncated  bool       `json:"truncated"`
 	Page       int        `json:"page"`
 	TotalCount int        `json:"total_count"`
-	TotalPages int        `json:"total_pages"`
 }
 
 // GetTrees downloads a file of repository, ref can be branch/tag/commit.

--- a/gitea/repo_tree.go
+++ b/gitea/repo_tree.go
@@ -20,10 +20,13 @@ type GitEntry struct {
 
 // GitTreeResponse returns a git tree
 type GitTreeResponse struct {
-	SHA       string     `json:"sha"`
-	URL       string     `json:"url"`
-	Entries   []GitEntry `json:"tree"`
-	Truncated bool       `json:"truncated"`
+	SHA        string     `json:"sha"`
+	URL        string     `json:"url"`
+	Entries    []GitEntry `json:"tree"`
+	Truncated  bool       `json:"truncated"`
+	Page       int        `json:"page"`
+	TotalCount int        `json:"total_count"`
+	TotalPages int        `json:"total_pages"`
 }
 
 // GetTrees downloads a file of repository, ref can be branch/tag/commit.


### PR DESCRIPTION
This adds a few more fields to the GitTreeResponse so that when paging Git Tree api, we can know how many more pages and how many items there are.
