### PR TITLE
Add method to set Sudo header

### DIFF
--- a/gitea/gitea.go
+++ b/gitea/gitea.go
@@ -23,6 +23,7 @@ func Version() string {
 type Client struct {
 	url         string
 	accessToken string
+	sudo        string
 	client      *http.Client
 }
 
@@ -40,12 +41,20 @@ func (c *Client) SetHTTPClient(client *http.Client) {
 	c.client = client
 }
 
+// SetSudo sets username to impersonate.
+func (c *Client) SetSudo(sudo string) {
+	c.sudo = sudo
+}
+
 func (c *Client) doRequest(method, path string, header http.Header, body io.Reader) (*http.Response, error) {
 	req, err := http.NewRequest(method, c.url+"/api/v1"+path, body)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Authorization", "token "+c.accessToken)
+	if c.sudo != "" {
+		req.Header.Set("Sudo", c.sudo)
+	}
 	for k, v := range header {
 		req.Header[k] = v
 	}


### PR DESCRIPTION
Api doc says I can execute requests on behalf of another user by setting header `Sudo`

This PR adds such possibility 

Usage 
```golang
	client := gitea.NewClient(os.Getenv("GITEA_HOST"), os.Getenv("GITEA_TOKEN"))
	client.SetSudo(username) // this is new 
	userRepos, err := client.ListMyRepos()
```

If I have `GITEA_TOKEN` as Admin User but results will contain repos of `username`

For reference the test in Gitea that checks if Sudo works 
https://github.com/go-gitea/gitea/blob/7096085f2b07246315e95e394b180ce9729efbb0/integrations/api_admin_test.go#L81