### PR TITLE
Add MustChangePassword field to add/edit user for API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ _testmain.go
 *.prof
 
 coverage.out
+
+# JetBrains
+.idea

--- a/gitea/admin_user.go
+++ b/gitea/admin_user.go
@@ -1,4 +1,5 @@
 // Copyright 2015 The Gogs Authors. All rights reserved.
+// Copyright 2019 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
@@ -21,8 +22,9 @@ type CreateUserOption struct {
 	// swagger:strfmt email
 	Email string `json:"email" binding:"Required;Email;MaxSize(254)"`
 	// required: true
-	Password   string `json:"password" binding:"Required;MaxSize(255)"`
-	SendNotify bool   `json:"send_notify"`
+	Password           string `json:"password" binding:"Required;MaxSize(255)"`
+	MustChangePassword bool   `json:"must_change_password"`
+	SendNotify         bool   `json:"send_notify"`
 }
 
 // AdminCreateUser create a user
@@ -44,6 +46,7 @@ type EditUserOption struct {
 	// swagger:strfmt email
 	Email                   string `json:"email" binding:"Required;Email;MaxSize(254)"`
 	Password                string `json:"password" binding:"MaxSize(255)"`
+	MustChangePassword      bool   `json:"must_change_password"`
 	Website                 string `json:"website" binding:"MaxSize(50)"`
 	Location                string `json:"location" binding:"MaxSize(50)"`
 	Active                  *bool  `json:"active"`


### PR DESCRIPTION
As titled. Once merged, I can add the field to Gitea's API. This would allow instance owners to enforce users changing passwords.
