### PR TITLE
Increase Username MaxSize 35 -> 40

### DIFF
--- a/gitea/admin_user.go
+++ b/gitea/admin_user.go
@@ -16,7 +16,7 @@ type CreateUserOption struct {
 	SourceID  int64  `json:"source_id"`
 	LoginName string `json:"login_name"`
 	// required: true
-	Username string `json:"username" binding:"Required;AlphaDashDot;MaxSize(35)"`
+	Username string `json:"username" binding:"Required;AlphaDashDot;MaxSize(40)"`
 	FullName string `json:"full_name" binding:"MaxSize(100)"`
 	// required: true
 	// swagger:strfmt email


### PR DESCRIPTION
Change the `MaxSize` limit from 35 to 40 for the `Username` field. 

Accompanying change to https://github.com/go-gitea/gitea/pull/6178