### PR TITLE
Adds structures for repo file and blob APIs

### DIFF
--- a/gitea/git_blob.go
+++ b/gitea/git_blob.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Gitea Authors. All rights reserved.
+// Copyright 2019 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/gitea/repo_blob.go
+++ b/gitea/repo_blob.go
@@ -1,0 +1,14 @@
+// Copyright 2018 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package gitea
+
+// GitBlobResponse represents a git blob
+type GitBlobResponse struct {
+	Content  string `json:"content"`
+	Encoding string `json:"encoding"`
+	URL      string `json:"url"`
+	SHA      string `json:"sha"`
+	Size     int64  `json:"size"`
+}

--- a/gitea/repo_commit.go
+++ b/gitea/repo_commit.go
@@ -9,6 +9,13 @@ import (
 	"fmt"
 )
 
+// Identity for a person's identity like an author or committer
+type Identity struct {
+	Name string `json:"name" binding:"MaxSize(100)"`
+	// swagger:strfmt email
+	Email string `json:"email" binding:"MaxSize(254)"`
+}
+
 // CommitMeta contains meta information of a commit in terms of API.
 type CommitMeta struct {
 	URL string `json:"url"`
@@ -17,8 +24,7 @@ type CommitMeta struct {
 
 // CommitUser contains information of a user in the context of a commit.
 type CommitUser struct {
-	Name  string `json:"name"`
-	Email string `json:"email"`
+	*Identity
 	Date  string `json:"date"`
 }
 

--- a/gitea/repo_commit.go
+++ b/gitea/repo_commit.go
@@ -25,7 +25,7 @@ type CommitMeta struct {
 // CommitUser contains information of a user in the context of a commit.
 type CommitUser struct {
 	*Identity
-	Date  string `json:"date"`
+	Date string `json:"date"`
 }
 
 // RepoCommit contains information of a commit in the context of a repository.

--- a/gitea/repo_commit.go
+++ b/gitea/repo_commit.go
@@ -24,7 +24,7 @@ type CommitMeta struct {
 
 // CommitUser contains information of a user in the context of a commit.
 type CommitUser struct {
-	*Identity
+	Identity
 	Date string `json:"date"`
 }
 

--- a/gitea/repo_file.go
+++ b/gitea/repo_file.go
@@ -1,4 +1,5 @@
 // Copyright 2014 The Gogs Authors. All rights reserved.
+// Copyright 2019 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/gitea/repo_file.go
+++ b/gitea/repo_file.go
@@ -13,3 +13,89 @@ import (
 func (c *Client) GetFile(user, repo, ref, tree string) ([]byte, error) {
 	return c.getResponse("GET", fmt.Sprintf("/repos/%s/%s/raw/%s/%s", user, repo, ref, tree), nil, nil)
 }
+
+// IdentityOptions for a person's identity like an author or committer
+type IdentityOptions struct {
+	Name string `json:"name" binding:"MaxSize(100)"`
+	// swagger:strfmt email
+	Email string `json:"email" binding:"MaxSize(254)"`
+}
+
+// FileOptions options for all file APIs
+type FileOptions struct {
+	Message       string          `json:"message"" binding:"Required"`
+	BranchName    string          `json:"branch"`
+	NewBranchName string          `json:"new_branch"`
+	Author        IdentityOptions `json:"author"`
+	Committer     IdentityOptions `json:"committer"`
+}
+
+// CreateFileOptions options for creating files
+type CreateFileOptions struct {
+	*FileOptions
+	Content string `json:"content"`
+}
+
+// DeleteFileOptions options for deleting files (used for other File structs below)
+type DeleteFileOptions struct {
+	*FileOptions
+	SHA string `json:"sha" binding:"Required"`
+}
+
+// UpdateFileOptions options for updating files
+type UpdateFileOptions struct {
+	*DeleteFileOptions
+	Content  string `json:"content"`
+	FromPath string `json:"from_path binding:"MaxSize(500)`
+}
+
+// FileLinksResponse contains the links for a repo's file
+type FileLinksResponse struct {
+	Self    string `json:"url"`
+	GitURL  string `json:"git_url"`
+	HTMLURL string `json:"html_url"`
+}
+
+// FileContent contains information about a repo's file stats and content
+type FileContentResponse struct {
+	Name        string             `json:"name"`
+	Path        string             `json:"path"`
+	SHA         string             `json:"sha"`
+	Size        int64              `json:"size"`
+	URL         string             `json:"url"`
+	HTMLURL     string             `json:"html_url"`
+	GitURL      string             `json:"git_url"`
+	DownloadURL string             `json:"download_url"`
+	Type        string             `json:"type"`
+	Links       *FileLinksResponse `json:"_links"`
+}
+
+// FileCommit contains information generated from a Git commit for a repo's file.
+type FileCommitResponse struct {
+	*CommitMeta
+	HTMLURL   string        `json:"html_url"`
+	Author    *CommitUser   `json:"author"`
+	Committer *CommitUser   `json:"committer"`
+	Parents   []*CommitMeta `json:"parents"`
+	Message   string        `json:"message"`
+	Tree      *CommitMeta   `json:"tree"`
+}
+
+// FileResponse contains information about a repo's file
+type FileResponse struct {
+	Content      *FileContentResponse       `json:"content"`
+	Commit       *FileCommitResponse        `json:"commit"`
+	Verification *PayloadCommitVerification `json:"verification"`
+}
+
+// FileDeleteResponse contains information about a repo's file that was deleted
+type FileDeleteResponse struct {
+	Content      interface{}                `json:"content"` // to be set to nil
+	Commit       *FileCommitResponse        `json:"commit"`
+	Verification *PayloadCommitVerification `json:"verification"`
+}
+
+type FileError struct {
+	Message          string `json:"message"`
+	DocumentationUrl string ``
+}

--- a/gitea/repo_file.go
+++ b/gitea/repo_file.go
@@ -39,7 +39,7 @@ type DeleteFileOptions struct {
 type UpdateFileOptions struct {
 	*DeleteFileOptions
 	Content  string `json:"content"`
-	FromPath string `json:"from_path binding:"MaxSize(500)`
+	FromPath string `json:"from_path" binding:"MaxSize(500)"`
 }
 
 // FileLinksResponse contains the links for a repo's file

--- a/gitea/repo_file.go
+++ b/gitea/repo_file.go
@@ -26,19 +26,19 @@ type FileOptions struct {
 
 // CreateFileOptions options for creating files
 type CreateFileOptions struct {
-	*FileOptions
+	FileOptions
 	Content string `json:"content"`
 }
 
 // DeleteFileOptions options for deleting files (used for other File structs below)
 type DeleteFileOptions struct {
-	*FileOptions
+	FileOptions
 	SHA string `json:"sha" binding:"Required"`
 }
 
 // UpdateFileOptions options for updating files
 type UpdateFileOptions struct {
-	*DeleteFileOptions
+	DeleteFileOptions
 	Content  string `json:"content"`
 	FromPath string `json:"from_path" binding:"MaxSize(500)"`
 }
@@ -66,7 +66,7 @@ type FileContentResponse struct {
 
 // FileCommitResponse contains information generated from a Git commit for a repo's file.
 type FileCommitResponse struct {
-	*CommitMeta
+	CommitMeta
 	HTMLURL   string        `json:"html_url"`
 	Author    *CommitUser   `json:"author"`
 	Committer *CommitUser   `json:"committer"`

--- a/gitea/repo_file.go
+++ b/gitea/repo_file.go
@@ -16,11 +16,11 @@ func (c *Client) GetFile(user, repo, ref, tree string) ([]byte, error) {
 
 // FileOptions options for all file APIs
 type FileOptions struct {
-	Message       string          `json:"message" binding:"Required"`
-	BranchName    string          `json:"branch"`
-	NewBranchName string          `json:"new_branch"`
-	Author        Identity        `json:"author"`
-	Committer     Identity        `json:"committer"`
+	Message       string   `json:"message" binding:"Required"`
+	BranchName    string   `json:"branch"`
+	NewBranchName string   `json:"new_branch"`
+	Author        Identity `json:"author"`
+	Committer     Identity `json:"committer"`
 }
 
 // CreateFileOptions options for creating files

--- a/gitea/repo_file.go
+++ b/gitea/repo_file.go
@@ -49,7 +49,7 @@ type FileLinksResponse struct {
 	HTMLURL string `json:"html_url"`
 }
 
-// FileContent contains information about a repo's file stats and content
+// FileContentResponse contains information about a repo's file stats and content
 type FileContentResponse struct {
 	Name        string             `json:"name"`
 	Path        string             `json:"path"`
@@ -63,7 +63,7 @@ type FileContentResponse struct {
 	Links       *FileLinksResponse `json:"_links"`
 }
 
-// FileCommit contains information generated from a Git commit for a repo's file.
+// FileCommitResponse contains information generated from a Git commit for a repo's file.
 type FileCommitResponse struct {
 	*CommitMeta
 	HTMLURL   string        `json:"html_url"`
@@ -88,7 +88,8 @@ type FileDeleteResponse struct {
 	Verification *PayloadCommitVerification `json:"verification"`
 }
 
+// FileError contains informatoin on the error working with a file and the URL to the API documentation for correct syntax
 type FileError struct {
 	Message          string `json:"message"`
-	DocumentationUrl string `json:"documentation_url"`
+	DocumentationURL string `json:"documentation_url"`
 }

--- a/gitea/repo_file.go
+++ b/gitea/repo_file.go
@@ -20,8 +20,8 @@ type FileOptions struct {
 	Message       string   `json:"message" binding:"Required"`
 	BranchName    string   `json:"branch"`
 	NewBranchName string   `json:"new_branch"`
-	Author        Identity `json:"author"`
-	Committer     Identity `json:"committer"`
+	Author        *Identity `json:"author"`
+	Committer     *Identity `json:"committer"`
 }
 
 // CreateFileOptions options for creating files

--- a/gitea/repo_file.go
+++ b/gitea/repo_file.go
@@ -88,9 +88,3 @@ type FileDeleteResponse struct {
 	Commit       *FileCommitResponse        `json:"commit"`
 	Verification *PayloadCommitVerification `json:"verification"`
 }
-
-// FileError contains informatoin on the error working with a file and the URL to the API documentation for correct syntax
-type FileError struct {
-	Message          string `json:"message"`
-	DocumentationURL string `json:"documentation_url"`
-}

--- a/gitea/repo_file.go
+++ b/gitea/repo_file.go
@@ -14,20 +14,13 @@ func (c *Client) GetFile(user, repo, ref, tree string) ([]byte, error) {
 	return c.getResponse("GET", fmt.Sprintf("/repos/%s/%s/raw/%s/%s", user, repo, ref, tree), nil, nil)
 }
 
-// IdentityOptions for a person's identity like an author or committer
-type IdentityOptions struct {
-	Name string `json:"name" binding:"MaxSize(100)"`
-	// swagger:strfmt email
-	Email string `json:"email" binding:"MaxSize(254)"`
-}
-
 // FileOptions options for all file APIs
 type FileOptions struct {
-	Message       string          `json:"message"" binding:"Required"`
+	Message       string          `json:"message" binding:"Required"`
 	BranchName    string          `json:"branch"`
 	NewBranchName string          `json:"new_branch"`
-	Author        IdentityOptions `json:"author"`
-	Committer     IdentityOptions `json:"committer"`
+	Author        Identity        `json:"author"`
+	Committer     Identity        `json:"committer"`
 }
 
 // CreateFileOptions options for creating files

--- a/gitea/repo_file.go
+++ b/gitea/repo_file.go
@@ -20,8 +20,8 @@ type FileOptions struct {
 	Message       string   `json:"message" binding:"Required"`
 	BranchName    string   `json:"branch"`
 	NewBranchName string   `json:"new_branch"`
-	Author        *Identity `json:"author"`
-	Committer     *Identity `json:"committer"`
+	Author        Identity `json:"author"`
+	Committer     Identity `json:"committer"`
 }
 
 // CreateFileOptions options for creating files

--- a/gitea/repo_file.go
+++ b/gitea/repo_file.go
@@ -90,5 +90,5 @@ type FileDeleteResponse struct {
 
 type FileError struct {
 	Message          string `json:"message"`
-	DocumentationUrl string ``
+	DocumentationUrl string `json:"documentation_url"`
 }


### PR DESCRIPTION
These are changes to the SDK to work with the feature of Creating/Updating/Deleting/Viewing repo files in the API (https://github.com/go-gitea/gitea/issues/4762)

This adds a few structures to the SDK to handle API calls for files, creating, updating, deleting and viewing the blob. There are different input/output structures so that the API Swagger will respectively show slight differences for Create, Update and Delete input/output yet reuse code/names to keep everything unified.

These structures are identical to what one can find for GitHub's API in https://developer.github.com/v3/repos/contents/#create-a-file (and the other sections) and https://developer.github.com/v3/git/blobs/#get-a-blob

Dependent upon by the Gitea PR: https://github.com/go-gitea/gitea/pull/6314