### PR TITLE
Adds wrapper for blob content

### DIFF
--- a/gitea/git_blob.go
+++ b/gitea/git_blob.go
@@ -6,8 +6,9 @@ package gitea
 
 import (
 	"bytes"
-	"code.gitea.io/gitea/modules/git"
 	"encoding/json"
+
+	"code.gitea.io/gitea/modules/git"
 )
 
 // GitBlobResponse represents a git blob

--- a/gitea/git_blob.go
+++ b/gitea/git_blob.go
@@ -20,6 +20,7 @@ type BlobResponse struct {
 	Size     int64  `json:"size"`
 }
 
+// BlobContentReponse is a wrapper for a git.Blob to be serializable
 type BlobContentResponse struct {
 	*git.Blob
 }

--- a/gitea/git_blob.go
+++ b/gitea/git_blob.go
@@ -14,10 +14,10 @@ import (
 // BlobResponse represents a git blob
 type BlobResponse struct {
 	Content  *BlobContentResponse `json:"content"`
-	Encoding string `json:"encoding"`
-	URL      string `json:"url"`
-	SHA      string `json:"sha"`
-	Size     int64  `json:"size"`
+	Encoding string               `json:"encoding"`
+	URL      string               `json:"url"`
+	SHA      string               `json:"sha"`
+	Size     int64                `json:"size"`
 }
 
 // BlobContentResponse is a wrapper for a git.Blob to be serializable

--- a/gitea/git_blob.go
+++ b/gitea/git_blob.go
@@ -20,7 +20,7 @@ type BlobResponse struct {
 	Size     int64  `json:"size"`
 }
 
-// BlobContentReponse is a wrapper for a git.Blob to be serializable
+// BlobContentResponse is a wrapper for a git.Blob to be serializable
 type BlobContentResponse struct {
 	*git.Blob
 }

--- a/gitea/git_blob.go
+++ b/gitea/git_blob.go
@@ -25,7 +25,7 @@ type BlobContentResponse struct {
 }
 
 func (bc *BlobContentResponse) MarshalJSON() ([]byte, error) {
-	reader, err := bc.Blob.DataAsync()
+	reader, err := bc.DataAsync()
 	if err != nil {
 		return nil, err
 	}

--- a/gitea/git_blob.go
+++ b/gitea/git_blob.go
@@ -11,7 +11,7 @@ import (
 	"code.gitea.io/gitea/modules/git"
 )
 
-// GitBlobResponse represents a git blob
+// BlobResponse represents a git blob
 type BlobResponse struct {
 	Content  *BlobContentResponse `json:"content"`
 	Encoding string `json:"encoding"`

--- a/gitea/git_blob.go
+++ b/gitea/git_blob.go
@@ -21,7 +21,7 @@ type BlobResponse struct {
 }
 
 type BlobContentResponse struct {
-	Blob *git.Blob
+	*git.Blob
 }
 
 func (bc *BlobContentResponse) MarshalJSON() ([]byte, error) {

--- a/gitea/git_blob.go
+++ b/gitea/git_blob.go
@@ -4,11 +4,35 @@
 
 package gitea
 
+import (
+	"bytes"
+	"code.gitea.io/gitea/modules/git"
+	"encoding/json"
+)
+
 // GitBlobResponse represents a git blob
-type GitBlobResponse struct {
-	Content  string `json:"content"`
+type BlobResponse struct {
+	Content  *BlobContentResponse `json:"content"`
 	Encoding string `json:"encoding"`
 	URL      string `json:"url"`
 	SHA      string `json:"sha"`
 	Size     int64  `json:"size"`
+}
+
+type BlobContentResponse struct {
+	Blob *git.Blob
+}
+
+func (bc *BlobContentResponse) MarshalJSON() ([]byte, error) {
+	reader, err := bc.Blob.DataAsync()
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+	buf := new(bytes.Buffer)
+	_, err = buf.ReadFrom(reader)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(buf.Bytes())
 }

--- a/gitea/git_blob.go
+++ b/gitea/git_blob.go
@@ -25,6 +25,7 @@ type BlobContentResponse struct {
 	*git.Blob
 }
 
+// MarshalJSON Marshals the BlobContentResponse by reading the blob so it can be encoded to base64
 func (bc *BlobContentResponse) MarshalJSON() ([]byte, error) {
 	reader, err := bc.DataAsync()
 	if err != nil {

--- a/gitea/repo_file.go
+++ b/gitea/repo_file.go
@@ -30,17 +30,18 @@ type CreateFileOptions struct {
 	Content string `json:"content"`
 }
 
+// UpdateFileOptions options for updating files
+type UpdateFileOptions struct {
+	FileOptions
+	SHA string `json:"sha" binding:"Required"`
+	Content  string `json:"content"`
+	FromPath string `json:"from_path" binding:"MaxSize(500)"`
+}
+
 // DeleteFileOptions options for deleting files (used for other File structs below)
 type DeleteFileOptions struct {
 	FileOptions
 	SHA string `json:"sha" binding:"Required"`
-}
-
-// UpdateFileOptions options for updating files
-type UpdateFileOptions struct {
-	DeleteFileOptions
-	Content  string `json:"content"`
-	FromPath string `json:"from_path" binding:"MaxSize(500)"`
 }
 
 // FileLinksResponse contains the links for a repo's file

--- a/gitea/repo_file.go
+++ b/gitea/repo_file.go
@@ -33,7 +33,7 @@ type CreateFileOptions struct {
 // UpdateFileOptions options for updating files
 type UpdateFileOptions struct {
 	FileOptions
-	SHA string `json:"sha" binding:"Required"`
+	SHA      string `json:"sha" binding:"Required"`
 	Content  string `json:"content"`
 	FromPath string `json:"from_path" binding:"MaxSize(500)"`
 }


### PR DESCRIPTION
This change is made for issue https://github.com/go-gitea/gitea/issue/4762 in relation to review of https://github.com/go-gitea/gitea/pull/6314, making the Blob data be encoded on Marshalling.