### PR TITLE
Add option for client with custom http client

### DIFF
--- a/gitea/gitea.go
+++ b/gitea/gitea.go
@@ -36,6 +36,12 @@ func NewClient(url, token string) *Client {
 	}
 }
 
+// NewClientWithHTTP creates an API client with a custom http client
+func NewClientWithHTTP(url string, httpClient *http.Client) {
+	client := NewClient(url, "")
+	client.client = httpClient
+}
+
 // SetHTTPClient replaces default http.Client with user given one.
 func (c *Client) SetHTTPClient(client *http.Client) {
 	c.client = client
@@ -51,7 +57,9 @@ func (c *Client) doRequest(method, path string, header http.Header, body io.Read
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Authorization", "token "+c.accessToken)
+	if len(c.accessToken) != 0 {
+		req.Header.Set("Authorization", "token "+c.accessToken)
+	}
 	if c.sudo != "" {
 		req.Header.Set("Sudo", c.sudo)
 	}


### PR DESCRIPTION
This PR adds the option to use a custom http client to use for example oauth2.