### PR TITLE
Adds missing methods in the org API

### DIFF
--- a/gitea/org.go
+++ b/gitea/org.go
@@ -1,4 +1,5 @@
 // Copyright 2015 The Gogs Authors. All rights reserved.
+// Copyright 2019 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
@@ -33,6 +34,16 @@ func (c *Client) GetOrg(orgname string) (*Organization, error) {
 	return org, c.getParsedResponse("GET", fmt.Sprintf("/orgs/%s", orgname), nil, nil, org)
 }
 
+// CreateOrg creates an organization
+func (c *Client) CreateOrg(opt structs.CreateOrgOption) (*Organization, error) {
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return nil, err
+	}
+	org := new(Organization)
+	return org, c.getParsedResponse("POST", "/orgs", jsonHeader, bytes.NewReader(body), org)
+}
+
 // EditOrg modify one organization via options
 func (c *Client) EditOrg(orgname string, opt structs.EditOrgOption) error {
 	body, err := json.Marshal(&opt)
@@ -40,5 +51,11 @@ func (c *Client) EditOrg(orgname string, opt structs.EditOrgOption) error {
 		return err
 	}
 	_, err = c.getResponse("PATCH", fmt.Sprintf("/orgs/%s", orgname), jsonHeader, bytes.NewReader(body))
+	return err
+}
+
+// DeleteOrg deletes an organization
+func (c *Client) DeleteOrg(orgname string) error {
+	_, err := c.getResponse("DELETE", fmt.Sprintf("/orgs/%s", orgname), nil, nil)
 	return err
 }


### PR DESCRIPTION
Adds two missing methods in the org API:

- CreateOrg: creates an organization
- DeleteOrg: deletes an organization

fix #143 
